### PR TITLE
Move tasks under challenge

### DIFF
--- a/app/controllers/admin/criteria_controller.rb
+++ b/app/controllers/admin/criteria_controller.rb
@@ -2,10 +2,11 @@
 
 module Admin
   class CriteriaController < BaseController
-    helper_method :task, :criterium
+    helper_method :task, :criterium, :challenge
 
-    add_breadcrumb I18n.t('resources.tasks.plural'), :admin_tasks_path
-    add_breadcrumb I18n.t('resources.criteria.plural'), :admin_task_criteria_path
+    add_breadcrumb I18n.t('resources.challenges.plural'), :admin_challenges_path
+    add_breadcrumb I18n.t('resources.tasks.plural'), :admin_challenge_tasks_path
+    add_breadcrumb I18n.t('resources.criteria.plural'), :admin_challenge_task_criteria_path
 
     def index
       @paginator, @criteria = paginate task_criteria
@@ -21,7 +22,7 @@ module Admin
       @criterium = Repo::TaskCriterium.new(criterium_params.merge(task_id: task.id))
 
       if criterium.save
-        redirect_to(admin_task_criteria_path(task), notice: flash_message(:created, :criteria))
+        redirect_to(admin_challenge_task_criteria_path(challenge, task), notice: flash_message(:created, :criteria))
       else
         render :new, status: :unprocessable_entity
       end
@@ -33,7 +34,7 @@ module Admin
 
     def update
       if criterium.update(criterium_params)
-        redirect_to(admin_task_criteria_path(task),
+        redirect_to(admin_challenge_task_criteria_path(challenge, task),
                     notice: flash_message(:updated, :criteria))
       else
         render :edit, status: :unprocessable_entity
@@ -42,7 +43,7 @@ module Admin
 
     def destroy
       criterium.destroy
-      redirect_to(admin_task_criteria_path,
+      redirect_to(admin_challenge_task_criteria_path(challenge, task),
                   notice: flash_message(:removed, :criteria))
     end
 
@@ -58,6 +59,10 @@ module Admin
 
     def criterium
       @criterium ||= Repo::TaskCriterium.find(params[:id])
+    end
+
+    def challenge
+      @challenge ||= task.challenge
     end
 
     def criterium_params

--- a/app/controllers/admin/task_submissions_controller.rb
+++ b/app/controllers/admin/task_submissions_controller.rb
@@ -4,8 +4,9 @@ module Admin
   class TaskSubmissionsController < BaseController
     helper_method :task, :task_submission, :member
 
-    add_breadcrumb I18n.t('resources.tasks.plural'), :admin_tasks_path
-    add_breadcrumb I18n.t('resources.task_submissions.plural'), :admin_task_submissions_path
+    add_breadcrumb I18n.t('resources.challenges.plural'), :admin_challenges_path
+    add_breadcrumb I18n.t('resources.tasks.plural'), :admin_challenge_tasks_path
+    add_breadcrumb I18n.t('resources.task_submissions.plural'), :admin_challenge_task_submissions_path
 
     def index
       @paginator, @task_submissions = paginate task.task_submissions.preload(member: :user)
@@ -13,7 +14,8 @@ module Admin
 
     def destroy
       task_submission.destroy
-      redirect_to(admin_task_submissions_path(task), notice: flash_message(:removed, :task_submissions))
+      redirect_to(admin_challenge_task_submissions_path(challenge, task),
+                  notice: flash_message(:removed, :task_submissions))
     end
 
     private

--- a/app/controllers/admin/task_submissions_controller.rb
+++ b/app/controllers/admin/task_submissions_controller.rb
@@ -2,7 +2,7 @@
 
 module Admin
   class TaskSubmissionsController < BaseController
-    helper_method :task, :task_submission, :member
+    helper_method :task, :task_submission, :challenge
 
     add_breadcrumb I18n.t('resources.challenges.plural'), :admin_challenges_path
     add_breadcrumb I18n.t('resources.tasks.plural'), :admin_challenge_tasks_path
@@ -26,6 +26,10 @@ module Admin
 
     def task
       @task ||= Repo::Task.friendly.preload(:challenge).find(params[:task_id])
+    end
+
+    def challenge
+      @challenge ||= task.challenge
     end
   end
 end

--- a/app/controllers/admin/tasks_controller.rb
+++ b/app/controllers/admin/tasks_controller.rb
@@ -2,12 +2,13 @@
 
 module Admin
   class TasksController < BaseController
-    helper_method :task
+    helper_method :task, :challenge
 
-    add_breadcrumb I18n.t('resources.tasks.plural'), :admin_tasks_path
+    add_breadcrumb I18n.t('resources.challenges.plural'), :admin_challenges_path
+    add_breadcrumb I18n.t('resources.tasks.plural'), :admin_challenge_tasks_path
 
     def index
-      @paginator, @tasks = paginate Repo::Task.preload(:challenge).all
+      @paginator, @tasks = paginate challenge_tasks
     end
 
     def new
@@ -20,7 +21,7 @@ module Admin
       @task = Repo::Task.new(task_params)
 
       if task.save
-        redirect_to(edit_admin_task_path(task), notice: flash_message(:created, :tasks))
+        redirect_to(edit_admin_challenge_task_path(challenge, task), notice: flash_message(:created, :tasks))
       else
         render :new, status: :unprocessable_entity
       end
@@ -33,13 +34,21 @@ module Admin
 
     def update
       if task.update(task_params)
-        redirect_to(admin_tasks_path, notice: flash_message(:updated, :tasks))
+        redirect_to(admin_challenge_tasks_path(challenge), notice: flash_message(:updated, :tasks))
       else
         render :edit, status: :unprocessable_entity
       end
     end
 
     private
+
+    def challenge_tasks
+      @challenge_tasks ||= Repo::Task.preload(:challenge).where(challenge:)
+    end
+
+    def challenge
+      @challenge ||= Repo::Challenge.friendly.find(params[:challenge_id])
+    end
 
     def task
       @task ||= Repo::Task.preload(:challenge).friendly.find(params[:id])

--- a/app/views/admin/challenges/index.html.erb
+++ b/app/views/admin/challenges/index.html.erb
@@ -31,6 +31,8 @@
     </th>
     <th>
     </th>
+    <th>
+    </th>
   </thead>
   <tbody>
     <% @challenges.each do |challenge| %>
@@ -49,6 +51,9 @@
         </td>
         <td class="text-center">
           <%= render(UI::TimestampComponent.new(data: challenge.finish_at)) %>
+        </td>
+        <td class="text-center">
+          <%= link_to t('resources.tasks.plural'), admin_challenge_tasks_path(challenge) %>
         </td>
         <td class="text-center">
           <%= link_to t('resources.members.plural'), admin_challenge_members_path(challenge) %>

--- a/app/views/admin/criteria/edit.html.erb
+++ b/app/views/admin/criteria/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="md:w-2/3 w-full">
   <h2 class="<%= UI::H2 %>"><%= t('words.edit') %> <%= t('resources.criteria.singular') %></h2>
 
-  <%= form_with(model: criterium, scope: :criterium, url: admin_task_criterium_path(task, criterium), method: :put, class: "contents") do |form| %>
+  <%= form_with(model: criterium, scope: :criterium, url: admin_challenge_task_criterium_path(challenge, task, criterium), method: :put, class: "contents") do |form| %>
     <div class="my-5">
       <%= form.label :title, class: UI::FORM_LABEL %>
       <%= form.text_field :title, autofocus: true, class: UI::FORM_INPUT %>
@@ -16,12 +16,12 @@
 
     <div class="flex items-center justify-between">
       <%= form.submit t('words.update'), class: UI::BUTTON_PRIMARY %>
-      <%= link_to t('words.back'), admin_task_criteria_path(task), class: UI::BUTTON_SECONDARY %>
+      <%= link_to t('words.back'), admin_challenge_task_criteria_path(challenge, task), class: UI::BUTTON_SECONDARY %>
     </div>
   <% end %>
 </div>
 
 <div class="mt-8">
   <%= t('words.danger') %>
-  <%= button_to t('words.remove'), admin_task_criterium_path(task, criterium), method: :delete, class: UI::BUTTON_DANGER, form: {data: {turbo_confirm: 'Are you sure?'}} %>
+  <%= button_to t('words.remove'), admin_challenge_task_criterium_path(challenge, task, criterium), method: :delete, class: UI::BUTTON_DANGER, form: {data: {turbo_confirm: 'Are you sure?'}} %>
 </div>

--- a/app/views/admin/criteria/index.html.erb
+++ b/app/views/admin/criteria/index.html.erb
@@ -1,7 +1,7 @@
 <div class="flex justify-between items-center py-3">
   <h2 class="<%= UI::H2 %>"><%= t('resources.criteria.plural') %></h2>
 
-  <%= link_to t('words.add'), new_admin_task_criterium_path, class: UI::BUTTON_PRIMARY %>
+  <%= link_to t('words.add'), new_admin_challenge_task_criterium_path, class: UI::BUTTON_PRIMARY %>
 </div>
 
 <table id="criteria" class="table">
@@ -17,7 +17,7 @@
     <% @criteria.each do |criterium| %>
       <tr id="criterium-<%= criterium.id %>">
         <td>
-          <%= link_to criterium.title, edit_admin_task_criterium_path(task, criterium) %>
+          <%= link_to criterium.title, edit_admin_challenge_task_criterium_path(challenge, task, criterium) %>
         </td>
         <td>
           <%= criterium.max_value %>

--- a/app/views/admin/criteria/new.html.erb
+++ b/app/views/admin/criteria/new.html.erb
@@ -1,7 +1,7 @@
 <div class="md:w-2/3 w-full">
   <h2 class="<%= UI::H2 %>"><%= t('words.new') %> <%= t('resources.criteria.singular') %></h2>
 
-  <%= form_with(model: @criterium, scope: :criterium, url: admin_task_criteria_path, method: :post, class: "contents") do |form| %>
+  <%= form_with(model: @criterium, scope: :criterium, url: admin_challenge_task_criteria_path, method: :post, class: "contents") do |form| %>
     <div class="my-5">
       <%= form.label :title, class: UI::FORM_LABEL %>
       <%= form.text_field :title, autofocus: true, class: UI::FORM_INPUT %>
@@ -16,7 +16,7 @@
 
     <div class="flex items-center justify-between">
       <%= form.submit t('words.create'), class: UI::BUTTON_PRIMARY %>
-      <%= link_to t('words.back'), admin_task_criteria_path(task), class: UI::BUTTON_SECONDARY %>
+      <%= link_to t('words.back'), admin_challenge_task_criteria_path(challenge, task), class: UI::BUTTON_SECONDARY %>
     </div>
   <% end %>
 

--- a/app/views/admin/task_submissions/index.html.erb
+++ b/app/views/admin/task_submissions/index.html.erb
@@ -25,7 +25,7 @@
           <%= task_submission.notes %>
         </td>
         <td class="text-center">
-          <%= button_to t('words.remove'), admin_task_submission_path(task, task_submission), method: :delete, class: UI::BUTTON_DANGER, form: { data: { turbo_confirm: t('messages.are_you_sure') } } %>
+          <%= button_to t('words.remove'), admin_challenge_task_submission_path(task.challenge, task, task_submission), method: :delete, class: UI::BUTTON_DANGER, form: { data: { turbo_confirm: t('messages.are_you_sure') } } %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/task_submissions/index.html.erb
+++ b/app/views/admin/task_submissions/index.html.erb
@@ -25,7 +25,7 @@
           <%= task_submission.notes %>
         </td>
         <td class="text-center">
-          <%= button_to t('words.remove'), admin_challenge_task_submission_path(task.challenge, task, task_submission), method: :delete, class: UI::BUTTON_DANGER, form: { data: { turbo_confirm: t('messages.are_you_sure') } } %>
+          <%= button_to t('words.remove'), admin_challenge_task_submission_path(challenge, task, task_submission), method: :delete, class: UI::BUTTON_DANGER, form: { data: { turbo_confirm: t('messages.are_you_sure') } } %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/tasks/edit.html.erb
+++ b/app/views/admin/tasks/edit.html.erb
@@ -3,7 +3,7 @@
     <%= task.title %>
   </h2>
 
-  <%= form_with(model: task, scope: :task, url: admin_task_path(task), method: :put, class: "contents") do |form| %>
+  <%= form_with(model: task, scope: :task, url: admin_challenge_task_path(challenge, task), method: :put, class: "contents") do |form| %>
     <div class="my-5">
       <%= form.label :title, class: UI::FORM_LABEL %>
       <%= form.text_field :title, autofocus: true, class: UI::FORM_INPUT %>
@@ -64,7 +64,7 @@
 
     <div class="flex items-center justify-between">
       <%= form.submit class: UI::BUTTON_PRIMARY %>
-      <%= link_to t('words.back'), admin_tasks_path, class: UI::BUTTON_SECONDARY %>
+      <%= link_to t('words.back'), admin_challenge_tasks_path(challenge), class: UI::BUTTON_SECONDARY %>
     </div>
   <% end %>
 

--- a/app/views/admin/tasks/index.html.erb
+++ b/app/views/admin/tasks/index.html.erb
@@ -1,3 +1,8 @@
+<div class="">
+  <h2 class="<%= UI::H2 %>">
+    <%= link_to challenge.title, edit_admin_challenge_path(challenge) %>
+ </h2>
+</div>
 <div class="flex justify-between items-center py-3">
   <h2 class="<%= UI::H2 %>"><%= t('resources.tasks.plural') %></h2>
 
@@ -8,9 +13,6 @@
   <thead>
     <th class="text-left">
       <%= t('resources.tasks.title') %>
-    </th>
-    <th>
-      <%= t('resources.challenges.singular') %>
     </th>
     <th class="text-center">
       <%= t('resources.tasks.start_at') %>
@@ -31,9 +33,6 @@
       <tr id="task-<%= task.id %>">
         <td>
           <%= link_to task.title, edit_admin_challenge_task_path(challenge, task) %>
-        </td>
-         <td>
-          <%= link_to task.challenge.title, edit_admin_challenge_path(task.challenge) %>
         </td>
         <td class="text-center">
           <%= render(UI::TimestampComponent.new(data: task.start_at)) %>

--- a/app/views/admin/tasks/index.html.erb
+++ b/app/views/admin/tasks/index.html.erb
@@ -1,7 +1,7 @@
 <div class="flex justify-between items-center py-3">
   <h2 class="<%= UI::H2 %>"><%= t('resources.tasks.plural') %></h2>
 
-  <%= link_to t('words.add'), new_admin_task_path, class: UI::BUTTON_PRIMARY %>
+  <%= link_to t('words.add'), new_admin_challenge_task_path(challenge), class: UI::BUTTON_PRIMARY %>
 </div>
 
 <table id="tasks" class="table">
@@ -30,7 +30,7 @@
     <% @tasks.each do |task| %>
       <tr id="task-<%= task.id %>">
         <td>
-          <%= link_to task.title, edit_admin_task_path(task) %>
+          <%= link_to task.title, edit_admin_challenge_task_path(challenge, task) %>
         </td>
          <td>
           <%= link_to task.challenge.title, edit_admin_challenge_path(task.challenge) %>
@@ -45,7 +45,7 @@
           <%= render(UI::TimestampComponent.new(data: task.result_at)) %>
         </td>
         <td class="text-center">
-          <%= link_to t('resources.task_submissions.plural'), admin_task_submissions_path(task) %>
+          <%= link_to t('resources.task_submissions.plural'), admin_challenge_task_submissions_path(challenge, task) %>
         </td>
         <td class="text-center">
           <%= link_to t('resources.criteria.plural'), admin_task_criteria_path(task) %>

--- a/app/views/admin/tasks/index.html.erb
+++ b/app/views/admin/tasks/index.html.erb
@@ -47,7 +47,7 @@
           <%= link_to t('resources.task_submissions.plural'), admin_challenge_task_submissions_path(challenge, task) %>
         </td>
         <td class="text-center">
-          <%= link_to t('resources.criteria.plural'), admin_task_criteria_path(task) %>
+          <%= link_to t('resources.criteria.plural'), admin_challenge_task_criteria_path(challenge, task) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/tasks/new.html.erb
+++ b/app/views/admin/tasks/new.html.erb
@@ -1,7 +1,7 @@
 <div class="md:w-2/3 w-full">
   <h2 class="<%= UI::H2 %>"><%= t('words.new') %> <%= t('resources.tasks.singular') %></h2>
 
-  <%= form_with(model: @task, scope: :task, url: admin_tasks_path, method: :post, class: "contents") do |form| %>
+  <%= form_with(model: @task, scope: :task, url: admin_challenge_tasks_path(challenge), method: :post, class: "contents") do |form| %>
     <div class="my-5">
       <%= form.label :title, class: UI::FORM_LABEL %>
       <%= form.text_field :title, autofocus: true, class: UI::FORM_INPUT %>
@@ -16,7 +16,7 @@
 
     <div class="flex items-center justify-between">
       <%= form.submit t('words.create'), class: UI::BUTTON_PRIMARY %>
-      <%= link_to t('words.back'), admin_tasks_path, class: UI::BUTTON_SECONDARY %>
+      <%= link_to t('words.back'), admin_challenge_tasks_path(challenge), class: UI::BUTTON_SECONDARY %>
     </div>
   <% end %>
 

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -22,9 +22,6 @@
             <%= link_to t('resources.challenges.plural'), admin_challenges_path %>
           </li>
           <li class="py-1">
-            <%= link_to t('resources.tasks.plural'), admin_tasks_path %>
-          </li>
-          <li class="py-1">
             <%= link_to t('resources.taxonomies.plural'), admin_taxonomies_path %>
           </li>
           <li class="py-1">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,10 +24,10 @@ Rails.application.routes.draw do
 
     resources :challenges, except: %i[destroy], concerns: :manage_taxonomies, repo: :challenges do
       resources :members, except: :show
-    end
-    resources :tasks, except: %i[destroy] do
-      resources :task_submissions, only: %i[index destroy], as: :submissions, path: :submissions
-      resources :criteria, except: :show
+      resources :tasks, except: %i[destroy] do
+        resources :task_submissions, only: %i[index destroy], as: :submissions, path: :submissions
+        resources :criteria, except: :show
+      end
     end
     resources :judges, only: :index
     resources :users, except: %i[show]

--- a/spec/features/admin/criteria/create_spec.rb
+++ b/spec/features/admin/criteria/create_spec.rb
@@ -4,9 +4,10 @@ require 'rails_helper'
 
 RSpec.describe 'Admin/Criteria/Create' do
   let!(:task) { create(:task) }
+  let!(:challenge) { task.challenge }
 
   it 'failure without session' do
-    visit "/admin/tasks/#{task.slug}/criteria/new"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria/new"
 
     expect(page).to have_current_path '/login'
     expect(page).to have_content 'You need to sign in or sign up before continuing.'
@@ -14,7 +15,7 @@ RSpec.describe 'Admin/Criteria/Create' do
 
   it 'failure without admin account' do
     assume_logged_in
-    visit "/admin/tasks/#{task.slug}/criteria/new"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria/new"
 
     expect(page).to have_current_path '/'
     expect(page).to have_content 'Access denied'
@@ -22,7 +23,7 @@ RSpec.describe 'Admin/Criteria/Create' do
 
   it 'failure with invalid params' do
     assume_logged_in(admin: true)
-    visit "/admin/tasks/#{task.slug}/criteria/new"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria/new"
 
     fill_in 'Max value', with: '0'
     click_button 'Create'
@@ -31,19 +32,19 @@ RSpec.describe 'Admin/Criteria/Create' do
       expect(page).to have_content 'must be greater than 0'
     end
 
-    expect(page).to have_current_path "/admin/tasks/#{task.slug}/criteria"
+    expect(page).to have_current_path "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria"
     expect(page).not_to have_content 'Criterion was successfully created'
   end
 
   it 'success' do
     assume_logged_in(admin: true)
-    visit "/admin/tasks/#{task.slug}/criteria/new"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria/new"
 
     fill_in 'Title', with: 'new criterion'
     fill_in 'Max value', with: 10
     click_button 'Create'
 
-    expect(page).to have_current_path "/admin/tasks/#{task.slug}/criteria"
+    expect(page).to have_current_path "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria"
     expect(page).to have_content 'Criterion was successfully created'
   end
 end

--- a/spec/features/admin/criteria/index_spec.rb
+++ b/spec/features/admin/criteria/index_spec.rb
@@ -6,9 +6,10 @@ RSpec.describe 'Admin/Criteria/Index' do
   let!(:task) { create(:task) }
   let!(:criterium1) { create(:task_criterium, task:) }
   let!(:criterium2) { create(:task_criterium, task:) }
+  let!(:challenge) { task.challenge }
 
   it 'failure without session' do
-    visit "/admin/tasks/#{task.slug}/criteria"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria"
 
     expect(page).to have_current_path '/login'
     expect(page).to have_content 'You need to sign in or sign up before continuing.'
@@ -16,7 +17,7 @@ RSpec.describe 'Admin/Criteria/Index' do
 
   it 'failure without admin account' do
     assume_logged_in
-    visit "/admin/tasks/#{task.slug}/criteria"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria"
 
     expect(page).to have_current_path '/'
     expect(page).to have_content 'Access denied'
@@ -24,10 +25,13 @@ RSpec.describe 'Admin/Criteria/Index' do
 
   it 'success' do
     assume_logged_in(admin: true)
-    visit "/admin/tasks/#{task.slug}/criteria"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria"
 
     within "#criterium-#{criterium1.id}" do
-      expect(page).to have_link criterium1.title, href: "/admin/tasks/#{task.slug}/criteria/#{criterium1.id}/edit"
+      expect(page).to have_link(
+        criterium1.title,
+        href: "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria/#{criterium1.id}/edit"
+      )
       expect(page).to have_content criterium1.title
       expect(page).to have_content criterium1.max_value
     end
@@ -35,12 +39,18 @@ RSpec.describe 'Admin/Criteria/Index' do
 
   it 'handles pagination' do
     assume_logged_in(admin: true)
-    visit "/admin/tasks/#{task.slug}/criteria?per_page=1"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria?per_page=1"
 
     within '.pagination' do
       expect(page).to have_css "span[class='page active']", text: '1'
-      expect(page).to have_css "a[href='/admin/tasks/#{task.slug}/criteria?per_page=1&page=2']", text: '2'
-      expect(page).to have_css "a[href='/admin/tasks/#{task.slug}/criteria?per_page=1&page=2']", text: 'Next'
+      expect(page).to have_css(
+        "a[href='/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria?per_page=1&page=2']",
+        text: '2'
+      )
+      expect(page).to have_css(
+        "a[href='/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria?per_page=1&page=2']",
+        text: 'Next'
+      )
     end
 
     expect(page).to have_css "#criterium-#{criterium1.id}"
@@ -48,7 +58,9 @@ RSpec.describe 'Admin/Criteria/Index' do
 
     within '.pagination' do
       click_link 'Next'
-      expect(page).to have_current_path "/admin/tasks/#{task.slug}/criteria?per_page=1&page=2"
+      expect(page).to have_current_path(
+        "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria?per_page=1&page=2"
+      )
     end
 
     expect(page).to have_css "#criterium-#{criterium2.id}"

--- a/spec/features/admin/criteria/remove_spec.rb
+++ b/spec/features/admin/criteria/remove_spec.rb
@@ -5,14 +5,15 @@ require 'rails_helper'
 RSpec.describe 'Admin/Criteria/Remove' do
   let(:criterium) { create(:task_criterium) }
   let!(:task) { criterium.task }
+  let!(:challenge) { task.challenge }
 
   it 'success' do
     assume_logged_in(admin: true)
-    visit "/admin/tasks/#{task.slug}/criteria/#{criterium.id}/edit"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria/#{criterium.id}/edit"
 
     click_button 'Remove'
 
-    expect(page).to have_current_path "/admin/tasks/#{task.slug}/criteria"
+    expect(page).to have_current_path "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria"
     expect(page).to have_content 'Criterion was successfully removed'
   end
 end

--- a/spec/features/admin/criteria/update_spec.rb
+++ b/spec/features/admin/criteria/update_spec.rb
@@ -5,9 +5,10 @@ require 'rails_helper'
 RSpec.describe 'Admin/Criteria/Update' do
   let(:criterium) { create(:task_criterium) }
   let!(:task) { criterium.task }
+  let!(:challenge) { task.challenge }
 
   it 'failure without session' do
-    visit "/admin/tasks/#{task.slug}/criteria/#{criterium.id}/edit"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria/#{criterium.id}/edit"
 
     expect(page).to have_current_path '/login'
     expect(page).to have_content 'You need to sign in or sign up before continuing.'
@@ -15,7 +16,7 @@ RSpec.describe 'Admin/Criteria/Update' do
 
   it 'failure without admin account' do
     assume_logged_in
-    visit "/admin/tasks/#{task.slug}/criteria/#{criterium.id}/edit"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria/#{criterium.id}/edit"
 
     expect(page).to have_current_path '/'
     expect(page).to have_content 'Access denied'
@@ -23,7 +24,7 @@ RSpec.describe 'Admin/Criteria/Update' do
 
   it 'failure with zero max_value' do
     assume_logged_in(admin: true)
-    visit "/admin/tasks/#{task.slug}/criteria/#{criterium.id}/edit"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria/#{criterium.id}/edit"
 
     fill_in 'Max value', with: '0'
     click_button 'Update'
@@ -31,24 +32,27 @@ RSpec.describe 'Admin/Criteria/Update' do
       expect(page).to have_content 'must be greater than 0'
     end
 
-    expect(page).to have_current_path "/admin/tasks/#{task.slug}/criteria/#{criterium.id}"
+    expect(page).to have_current_path "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria/#{criterium.id}"
     expect(page).not_to have_content 'Criterion was successfully updated'
   end
 
   it 'success' do
     assume_logged_in(admin: true)
-    visit "/admin/tasks/#{task.slug}/criteria/#{criterium.id}/edit"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria/#{criterium.id}/edit"
 
     fill_in 'Title', with: 'new criterion'
     fill_in 'Max value', with: 10
 
     click_button 'Update'
 
-    expect(page).to have_current_path "/admin/tasks/#{task.slug}/criteria"
+    expect(page).to have_current_path "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria"
     expect(page).to have_content 'Criterion was successfully updated'
 
     within "#criterium-#{criterium.id}" do
-      expect(page).to have_link criterium.reload.title, href: "/admin/tasks/#{task.slug}/criteria/#{criterium.id}/edit"
+      expect(page).to have_link(
+        criterium.reload.title,
+        href: "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/criteria/#{criterium.id}/edit"
+      )
       expect(page).to have_content criterium.max_value
     end
   end

--- a/spec/features/admin/task_submissions/index_spec.rb
+++ b/spec/features/admin/task_submissions/index_spec.rb
@@ -42,8 +42,14 @@ RSpec.describe 'Admin/TaskSubmissions/Index' do
 
     within '.pagination' do
       expect(page).to have_css "span[class='page active']", text: '1'
-      expect(page).to have_css "a[href='/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/submissions?per_page=1&page=2']", text: '2'
-      expect(page).to have_css "a[href='/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/submissions?per_page=1&page=2']", text: 'Next'
+      expect(page).to have_css(
+        "a[href='/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/submissions?per_page=1&page=2']",
+        text: '2'
+      )
+      expect(page).to have_css(
+        "a[href='/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/submissions?per_page=1&page=2']",
+        text: 'Next'
+      )
     end
 
     expect(page).to have_css "#task_submission-#{task_submission_a.id}"
@@ -51,7 +57,9 @@ RSpec.describe 'Admin/TaskSubmissions/Index' do
 
     within '.pagination' do
       click_link 'Next'
-      expect(page).to have_current_path "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/submissions?per_page=1&page=2"
+      expect(page).to have_current_path(
+        "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/submissions?per_page=1&page=2"
+      )
     end
 
     expect(page).to have_css "#task_submission-#{task_submission_b.id}"

--- a/spec/features/admin/task_submissions/index_spec.rb
+++ b/spec/features/admin/task_submissions/index_spec.rb
@@ -4,9 +4,10 @@ require 'rails_helper'
 
 RSpec.describe 'Admin/TaskSubmissions/Index' do
   let!(:task) { create(:task) }
+  let!(:challenge) { task.challenge }
 
   it 'failure without session' do
-    visit "/admin/tasks/#{task.slug}/submissions"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/submissions"
 
     expect(page).to have_current_path '/login'
     expect(page).to have_content 'You need to sign in or sign up before continuing.'
@@ -14,7 +15,7 @@ RSpec.describe 'Admin/TaskSubmissions/Index' do
 
   it 'failure without admin account' do
     assume_logged_in
-    visit "/admin/tasks/#{task.slug}/submissions"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/submissions"
 
     expect(page).to have_current_path '/'
     expect(page).to have_content 'Access denied'
@@ -24,7 +25,7 @@ RSpec.describe 'Admin/TaskSubmissions/Index' do
     task_submission = create(:task_submission, notes: 'first submission', task:)
 
     assume_logged_in(admin: true)
-    visit "/admin/tasks/#{task.slug}/submissions"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/submissions"
 
     within "#task_submission-#{task_submission.id}" do
       expect(page).to have_content task_submission.member.user.email
@@ -37,12 +38,12 @@ RSpec.describe 'Admin/TaskSubmissions/Index' do
     task_submission_b = create(:task_submission, task:)
 
     assume_logged_in(admin: true)
-    visit "/admin/tasks/#{task.slug}/submissions?per_page=1"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/submissions?per_page=1"
 
     within '.pagination' do
       expect(page).to have_css "span[class='page active']", text: '1'
-      expect(page).to have_css "a[href='/admin/tasks/#{task.slug}/submissions?per_page=1&page=2']", text: '2'
-      expect(page).to have_css "a[href='/admin/tasks/#{task.slug}/submissions?per_page=1&page=2']", text: 'Next'
+      expect(page).to have_css "a[href='/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/submissions?per_page=1&page=2']", text: '2'
+      expect(page).to have_css "a[href='/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/submissions?per_page=1&page=2']", text: 'Next'
     end
 
     expect(page).to have_css "#task_submission-#{task_submission_a.id}"
@@ -50,7 +51,7 @@ RSpec.describe 'Admin/TaskSubmissions/Index' do
 
     within '.pagination' do
       click_link 'Next'
-      expect(page).to have_current_path "/admin/tasks/#{task.slug}/submissions?per_page=1&page=2"
+      expect(page).to have_current_path "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/submissions?per_page=1&page=2"
     end
 
     expect(page).to have_css "#task_submission-#{task_submission_b.id}"

--- a/spec/features/admin/task_submissions/remove_spec.rb
+++ b/spec/features/admin/task_submissions/remove_spec.rb
@@ -6,9 +6,10 @@ RSpec.describe 'Admin/TaskSubmissions/Remove' do
   it 'success' do
     task_submission = create(:task_submission)
     task = task_submission.task
+    challenge = task.challenge
 
     assume_logged_in(admin: true)
-    visit "/admin/tasks/#{task.slug}/submissions"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/submissions"
 
     expect(page).to have_content task_submission.member.user.email
 
@@ -16,7 +17,7 @@ RSpec.describe 'Admin/TaskSubmissions/Remove' do
       click_button 'Remove'
     end
 
-    expect(page).to have_current_path "/admin/tasks/#{task.slug}/submissions"
+    expect(page).to have_current_path "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/submissions"
     expect(page).to have_content 'Task Submission was successfully removed'
     expect(page).not_to have_content task_submission.member.user.email
   end

--- a/spec/features/admin/tasks/create_spec.rb
+++ b/spec/features/admin/tasks/create_spec.rb
@@ -3,8 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin/Tasks/Create' do
+  let!(:challenge) { create(:challenge) }
+
   it 'failure without session' do
-    visit '/admin/tasks/new'
+    visit "/admin/challenges/#{challenge.slug}/tasks/new"
 
     expect(page).to have_current_path '/login'
     expect(page).to have_content 'You need to sign in or sign up before continuing.'
@@ -12,7 +14,7 @@ RSpec.describe 'Admin/Tasks/Create' do
 
   it 'failure without admin account' do
     assume_logged_in
-    visit '/admin/tasks/new'
+    visit "/admin/challenges/#{challenge.slug}/tasks/new"
 
     expect(page).to have_current_path '/'
     expect(page).to have_content 'Access denied'
@@ -20,7 +22,7 @@ RSpec.describe 'Admin/Tasks/Create' do
 
   it 'failure with invalid params' do
     assume_logged_in(admin: true)
-    visit '/admin/tasks/new'
+    visit "/admin/challenges/#{challenge.slug}/tasks/new"
 
     fill_in 'Title', with: ''
     click_button 'Create'
@@ -29,7 +31,7 @@ RSpec.describe 'Admin/Tasks/Create' do
       expect(page).to have_content "can't be blank"
     end
 
-    expect(page).to have_current_path '/admin/tasks'
+    expect(page).to have_current_path "/admin/challenges/#{challenge.slug}/tasks"
     expect(page).not_to have_content 'Task was successfully created'
   end
 
@@ -38,13 +40,13 @@ RSpec.describe 'Admin/Tasks/Create' do
 
     challenge = create(:challenge)
 
-    visit '/admin/tasks/new'
+    visit "/admin/challenges/#{challenge.slug}/tasks/new"
 
     fill_in 'Title', with: 'new task'
     select challenge.title, from: 'task_challenge_id'
     click_button 'Create'
 
-    expect(page).to have_current_path '/admin/tasks/new-task/edit'
+    expect(page).to have_current_path "/admin/challenges/#{challenge.slug}/tasks/new-task/edit"
     expect(page).to have_content 'Task was successfully created'
   end
 end

--- a/spec/features/admin/tasks/index_spec.rb
+++ b/spec/features/admin/tasks/index_spec.rb
@@ -26,12 +26,13 @@ RSpec.describe 'Admin/Tasks/Index' do
     assume_logged_in(admin: true)
     visit "/admin/challenges/#{challenge.slug}/tasks"
 
+    expect(page).to have_content task.challenge.title
+
     within "#task-#{task.id}" do
       expect(page).to have_link task.title, href: "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/edit"
       expect(page).to have_content task.start_at.strftime(UI::TimestampComponent::TIME_FORMAT)
       expect(page).to have_content task.submit_at.strftime(UI::TimestampComponent::TIME_FORMAT)
       expect(page).to have_content task.result_at.strftime(UI::TimestampComponent::TIME_FORMAT)
-      expect(page).to have_content task.challenge.title
     end
   end
 

--- a/spec/features/admin/tasks/index_spec.rb
+++ b/spec/features/admin/tasks/index_spec.rb
@@ -35,6 +35,24 @@ RSpec.describe 'Admin/Tasks/Index' do
     end
   end
 
+  it 'show tasks of the challenge' do
+    task_a = create(:task, challenge:)
+    task_b = create(:task, challenge:)
+    task_c = create(:task, challenge: build(:challenge))
+
+    assume_logged_in(admin: true)
+    visit "/admin/challenges/#{challenge.slug}/tasks"
+
+    expect(Repo::Task.count).to eq(3)
+    expect(page).to have_link task_a.title, href: "/admin/challenges/#{challenge.slug}/tasks/#{task_a.slug}/edit"
+    expect(page).to have_content task_a.challenge.title
+    expect(page).to have_link task_b.title, href: "/admin/challenges/#{challenge.slug}/tasks/#{task_b.slug}/edit"
+    expect(page).to have_content task_b.challenge.title
+
+    expect(page).not_to have_link task_c.title, href: "/admin/challenges/#{challenge.slug}/tasks/#{task_c.slug}/edit"
+    expect(page).not_to have_content task_c.challenge.title
+  end
+
   it 'handles pagination' do
     task_a = create(:task, challenge:)
     task_b = create(:task, challenge:)

--- a/spec/features/admin/tasks/index_spec.rb
+++ b/spec/features/admin/tasks/index_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Admin/Tasks/Index' do
     end
   end
 
-  it 'show tasks of the challenge' do
+  it 'shows tasks of the challenge' do
     task_a = create(:task, challenge:)
     task_b = create(:task, challenge:)
     task_c = create(:task, challenge: build(:challenge))

--- a/spec/features/admin/tasks/index_spec.rb
+++ b/spec/features/admin/tasks/index_spec.rb
@@ -3,8 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin/Tasks/Index' do
+  let!(:challenge) { create(:challenge) }
+
   it 'failure without session' do
-    visit '/admin/tasks'
+    visit "/admin/challenges/#{challenge.slug}/tasks"
 
     expect(page).to have_current_path '/login'
     expect(page).to have_content 'You need to sign in or sign up before continuing.'
@@ -12,20 +14,20 @@ RSpec.describe 'Admin/Tasks/Index' do
 
   it 'failure without admin account' do
     assume_logged_in
-    visit '/admin/tasks'
+    visit "/admin/challenges/#{challenge.slug}/tasks"
 
     expect(page).to have_current_path '/'
     expect(page).to have_content 'Access denied'
   end
 
   it 'success' do
-    task = create(:task)
+    task = create(:task, challenge:)
 
     assume_logged_in(admin: true)
-    visit '/admin/tasks'
+    visit "/admin/challenges/#{challenge.slug}/tasks"
 
     within "#task-#{task.id}" do
-      expect(page).to have_link task.title, href: "/admin/tasks/#{task.slug}/edit"
+      expect(page).to have_link task.title, href: "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/edit"
       expect(page).to have_content task.start_at.strftime(UI::TimestampComponent::TIME_FORMAT)
       expect(page).to have_content task.submit_at.strftime(UI::TimestampComponent::TIME_FORMAT)
       expect(page).to have_content task.result_at.strftime(UI::TimestampComponent::TIME_FORMAT)
@@ -34,16 +36,16 @@ RSpec.describe 'Admin/Tasks/Index' do
   end
 
   it 'handles pagination' do
-    task_a = create(:task)
-    task_b = create(:task)
+    task_a = create(:task, challenge:)
+    task_b = create(:task, challenge:)
 
     assume_logged_in(admin: true)
-    visit '/admin/tasks?per_page=1'
+    visit "/admin/challenges/#{challenge.slug}/tasks?per_page=1"
 
     within '.pagination' do
       expect(page).to have_css "span[class='page active']", text: '1'
-      expect(page).to have_css "a[href='/admin/tasks?per_page=1&page=2']", text: '2'
-      expect(page).to have_css "a[href='/admin/tasks?per_page=1&page=2']", text: 'Next'
+      expect(page).to have_css "a[href='/admin/challenges/#{challenge.slug}/tasks?per_page=1&page=2']", text: '2'
+      expect(page).to have_css "a[href='/admin/challenges/#{challenge.slug}/tasks?per_page=1&page=2']", text: 'Next'
     end
 
     expect(page).to have_css "#task-#{task_a.id}"
@@ -51,7 +53,7 @@ RSpec.describe 'Admin/Tasks/Index' do
 
     within '.pagination' do
       click_link 'Next'
-      expect(page).to have_current_path '/admin/tasks?per_page=1&page=2'
+      expect(page).to have_current_path "/admin/challenges/#{challenge.slug}/tasks?per_page=1&page=2"
     end
 
     expect(page).to have_css "#task-#{task_b.id}"
@@ -59,14 +61,14 @@ RSpec.describe 'Admin/Tasks/Index' do
   end
 
   it 'handles user time_zone' do
-    task = create(:task, start_at: '2022-05-01 10:00:00')
+    task = create(:task, start_at: '2022-05-01 10:00:00', challenge:)
     user = create(:user, :admin, time_zone: 'Kyiv')
 
     assume_logged_in(user)
-    visit '/admin/tasks'
+    visit "/admin/challenges/#{challenge.slug}/tasks"
 
     within "#task-#{task.id}" do
-      expect(page).to have_link task.title, href: "/admin/tasks/#{task.slug}/edit"
+      expect(page).to have_link task.title, href: "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/edit"
 
       expect(page).to have_content task
         .start_at

--- a/spec/features/admin/tasks/update_spec.rb
+++ b/spec/features/admin/tasks/update_spec.rb
@@ -75,13 +75,13 @@ RSpec.describe 'Admin/Tasks/Update' do
 
     expect(page).to have_current_path "/admin/challenges/#{challenge.slug}/tasks"
     expect(page).to have_content 'Task was successfully updated'
+    expect(page).to have_content task.challenge.title
 
     within "#task-#{task.id}" do
       expect(page).to have_content 'OK task'
       expect(page).to have_content Time.zone.parse('2022-05-01 10:00:00').strftime(UI::TimestampComponent::TIME_FORMAT)
       expect(page).to have_content Time.zone.parse('2022-05-10 09:00:00').strftime(UI::TimestampComponent::TIME_FORMAT)
       expect(page).to have_content Time.zone.parse('2022-05-15 18:00:00').strftime(UI::TimestampComponent::TIME_FORMAT)
-      expect(page).to have_content task.challenge.title
     end
   end
 end

--- a/spec/features/admin/tasks/update_spec.rb
+++ b/spec/features/admin/tasks/update_spec.rb
@@ -4,9 +4,10 @@ require 'rails_helper'
 
 RSpec.describe 'Admin/Tasks/Update' do
   let!(:task) { create(:task) }
+  let!(:challenge) { task.challenge }
 
   it 'failure without session' do
-    visit "/admin/tasks/#{task.slug}/edit"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/edit"
 
     expect(page).to have_current_path '/login'
     expect(page).to have_content 'You need to sign in or sign up before continuing.'
@@ -14,7 +15,7 @@ RSpec.describe 'Admin/Tasks/Update' do
 
   it 'failure without admin account' do
     assume_logged_in
-    visit "/admin/tasks/#{task.slug}/edit"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/edit"
 
     expect(page).to have_current_path '/'
     expect(page).to have_content 'Access denied'
@@ -22,7 +23,7 @@ RSpec.describe 'Admin/Tasks/Update' do
 
   it 'failure with empty title' do
     assume_logged_in(admin: true)
-    visit "/admin/tasks/#{task.slug}/edit"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/edit"
 
     fill_in 'Title', with: ''
     click_button 'Update'
@@ -30,13 +31,13 @@ RSpec.describe 'Admin/Tasks/Update' do
       expect(page).to have_content "can't be blank"
     end
 
-    expect(page).to have_current_path "/admin/tasks/#{task.slug}"
+    expect(page).to have_current_path "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}"
     expect(page).not_to have_content 'Task was successfully updated'
   end
 
   it 'failure with invalid timestamps' do
     assume_logged_in(admin: true)
-    visit "/admin/tasks/#{task.slug}/edit"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/edit"
 
     fill_in 'Start at',        with: '2022-04-06 15:33:14'
     fill_in 'Submit at',       with: '2022-04-06 15:33:13'
@@ -55,13 +56,13 @@ RSpec.describe 'Admin/Tasks/Update' do
       expect(page).to have_content 'must be greater than 2022-04-06 15:33:13 UTC'
     end
 
-    expect(page).to have_current_path "/admin/tasks/#{task.slug}"
+    expect(page).to have_current_path "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}"
     expect(page).not_to have_content 'Task was successfully updated'
   end
 
   it 'success' do
     assume_logged_in(admin: true)
-    visit "/admin/tasks/#{task.slug}/edit"
+    visit "/admin/challenges/#{challenge.slug}/tasks/#{task.slug}/edit"
 
     fill_in 'Title',                with: 'OK task'
     fill_in 'Slug',                 with: 'ok-task'
@@ -72,7 +73,7 @@ RSpec.describe 'Admin/Tasks/Update' do
 
     click_button 'Update'
 
-    expect(page).to have_current_path '/admin/tasks'
+    expect(page).to have_current_path "/admin/challenges/#{challenge.slug}/tasks"
     expect(page).to have_content 'Task was successfully updated'
 
     within "#task-#{task.id}" do

--- a/spec/features/auth/navigation_spec.rb
+++ b/spec/features/auth/navigation_spec.rb
@@ -64,9 +64,6 @@ RSpec.describe 'Navigation' do
         click_link 'Challenges'
         expect(page).to have_current_path '/admin/challenges'
 
-        click_link 'Tasks'
-        expect(page).to have_current_path '/admin/tasks'
-
         click_link 'Taxonomies'
         expect(page).to have_current_path '/admin/taxonomies'
 


### PR DESCRIPTION
Since a challenge has many tasks, so there is a sense
to move tasks under a challenge. That is a user should be able to
see a list of tasks for a particular challenge. But currently, 
we only have a button that allows us to see the list of all tasks.

This PR moves tasks (and task_submissions) under a challenge 
for admins.

**Changes:**
- update `tasks` routes from `/admin/tasks/` 
to `/admin/challenges/:challenge_id/tasks/`
- remove Task#index from admin dashboard
- add Task#index button to challenges table.
- update tasks and task_submissions urls everywhere
- update specs

---
<img width="1640" alt="Screenshot 2022-04-23 at 14 30 14" src="https://user-images.githubusercontent.com/43855653/164893224-2ea11ec3-c512-411c-9550-9278e15809f9.png">

<img width="1627" alt="Screenshot 2022-04-23 at 14 59 16" src="https://user-images.githubusercontent.com/43855653/164893593-6c322af8-b25c-4c27-9dbe-7aa23a3ed4d8.png">